### PR TITLE
Added set_pixels_per_point method

### DIFF
--- a/src/platform.rs
+++ b/src/platform.rs
@@ -231,6 +231,11 @@ impl Platform {
         }
     }
 
+    /// Sets points per pixel in egui. Useful for HiDPI screens.
+    pub fn set_pixels_per_point(&mut self, pixels_per_point: Option<f32>) {
+        self.raw_input.pixels_per_point = pixels_per_point;
+    }
+
     /// Update the time
     pub fn update_time(&mut self, duration: f64) {
         self.raw_input.time = Some(duration);


### PR DESCRIPTION
There is an issue with HiDPI screens (can reproduce on m1 MacBook).
SDL has a `window.size()` multiple times smaller than `window.draw_size()`. This leads to a situation where egui rasterizes with smaller logical units than there are pixels, effectively stretching the image and making everything blurry.

This PR allows setting a flag in egui that fixes this issue. I added it as a flag and not a constructor method because you can have multiple screens with different DPI's, and moving windows between these screens should change this unit (I think Windows supports that).