### PR TITLE
Update to egui 0.31

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = ["examples/*"]
 [dependencies]
 # Temporary commit ref to get SDL2 with correct raw_window_handle for use with wgpu
 sdl2 = { version = "0.37.0", features = ["raw-window-handle"] }
-egui = "0.27"
+egui = "0.29"
 anyhow = "1.0"
 log = "0.4"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = ["examples/*"]
 [dependencies]
 # Temporary commit ref to get SDL2 with correct raw_window_handle for use with wgpu
 sdl2 = { version = "0.37.0", features = ["raw-window-handle"] }
-egui = "0.29"
+egui = "0.31"
 anyhow = "1.0"
 log = "0.4"
 

--- a/examples/sdl2_plus_glow/Cargo.toml
+++ b/examples/sdl2_plus_glow/Cargo.toml
@@ -9,7 +9,7 @@ egui_sdl2_platform = { path = "../../", features = ["sdl2_use-pkgconfig"] }
 
 gl = "0.14"
 egui = "0.31"
-egui_glow = "0.29"
+egui_glow = "0.31"
 
 pollster = "0.2"
 anyhow = "1.0"

--- a/examples/sdl2_plus_glow/Cargo.toml
+++ b/examples/sdl2_plus_glow/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2021"
 egui_sdl2_platform = { path = "../../", features = ["sdl2_use-pkgconfig"] }
 
 gl = "0.14"
-egui = "0.27"
-egui_glow = "0.27"
+egui = "0.29"
+egui_glow = "0.29"
 
 pollster = "0.2"
 anyhow = "1.0"

--- a/examples/sdl2_plus_glow/Cargo.toml
+++ b/examples/sdl2_plus_glow/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 egui_sdl2_platform = { path = "../../", features = ["sdl2_use-pkgconfig"] }
 
 gl = "0.14"
-egui = "0.29"
+egui = "0.31"
 egui_glow = "0.29"
 
 pollster = "0.2"

--- a/examples/sdl2_plus_glow/src/main.rs
+++ b/examples/sdl2_plus_glow/src/main.rs
@@ -38,7 +38,7 @@ async fn run() -> anyhow::Result<()> {
             video.gl_get_proc_address(name) as *const _
         })
     };
-    let mut painter = egui_glow::Painter::new(Arc::new(gl), "", None).unwrap();
+    let mut painter = egui_glow::Painter::new(Arc::new(gl), "", None, true).unwrap();
 
     // Create the egui + sdl2 platform
     let mut platform = egui_sdl2_platform::Platform::new(window.size())?;

--- a/examples/sdl2_plus_wgpu/Cargo.toml
+++ b/examples/sdl2_plus_wgpu/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 # Include egui_sdl2_platform
 egui_sdl2_platform = { path = "../../" }
 
-wgpu = "0.20"
-egui = "0.27"
-egui_wgpu_backend = "0.29"
+wgpu = "23.0"
+egui = "0.29"
+egui_wgpu_backend = "0.32"
 pollster = "0.2"
 anyhow = "1.0"

--- a/examples/sdl2_plus_wgpu/Cargo.toml
+++ b/examples/sdl2_plus_wgpu/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 # Include egui_sdl2_platform
 egui_sdl2_platform = { path = "../../" }
 
-wgpu = "23.0"
-egui = "0.29"
-egui_wgpu_backend = "0.32"
+wgpu = "24.0"
+egui = "0.31"
+egui_wgpu_backend = "0.34"
 pollster = "0.2"
 anyhow = "1.0"

--- a/examples/sdl2_plus_wgpu/src/main.rs
+++ b/examples/sdl2_plus_wgpu/src/main.rs
@@ -24,7 +24,7 @@ async fn run() -> anyhow::Result<()> {
         .map_err(|e| anyhow::anyhow!("Failed to get sdl event pump: {}", e))?;
 
     // Create the wgpu instance
-    let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::default());
+    let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor::default());
     // Create the wgpu surface
     let surface = unsafe {
         instance.create_surface_unsafe(wgpu::SurfaceTargetUnsafe::from_window(&window)?)?

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -259,14 +259,18 @@ impl Platform {
         // Get the egui output
         let output = self.egui_ctx.end_pass();
         // Update the clipboard
-        if !output.platform_output.copied_text.is_empty() {
-            // Get the copied text
-            let text = output.platform_output.copied_text.clone();
-            // Update the clipboard
-            video
-                .clipboard()
-                .set_clipboard_text(&text)
-                .map_err(|e| anyhow::anyhow!("Failed to assign text to clipboard: {}", e))?;
+        for cmd in &output.platform_output.commands {
+            match cmd {
+                egui::OutputCommand::CopyText(text) => {
+                    video
+                        .clipboard()
+                        .set_clipboard_text(&text)
+                        .map_err(|e| anyhow::anyhow!("Failed to assign text to clipboard: {}", e))?;
+                }
+                egui::OutputCommand::CopyImage(_) | egui::OutputCommand::OpenUrl(_) => {
+                    // TODO: Handle CopyImage and OpenUrl commands
+                }
+            }
         }
 
         if let Some(cursor) = &mut self.cursor {

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -246,7 +246,7 @@ impl Platform {
     /// Return the processed context
     pub fn context(&mut self) -> egui::Context {
         // Begin the frame
-        self.egui_ctx.begin_frame(self.raw_input.take());
+        self.egui_ctx.begin_pass(self.raw_input.take());
         // Return the ctx
         self.egui_ctx.clone()
     }
@@ -257,7 +257,7 @@ impl Platform {
         video: &mut sdl2::VideoSubsystem,
     ) -> anyhow::Result<egui::FullOutput> {
         // Get the egui output
-        let output = self.egui_ctx.end_frame();
+        let output = self.egui_ctx.end_pass();
         // Update the clipboard
         if !output.platform_output.copied_text.is_empty() {
             // Get the copied text


### PR DESCRIPTION
- Integrates #7 from @rurunosep 
- + changes needed for egui 0.31 (using PlatformOutput.commands to get the copied text instead of the deprecated copied_text field) 
- Little update to the wgpu / glow examples 